### PR TITLE
[Feat] 반려견 믹스 비율 분석 기능 구현 및 결과 카드 시각화

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tensorflow-models/mobilenet": "^2.1.1",
     "@tensorflow/tfjs": "^4.22.0",
+    "html2canvas": "^1.4.1",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tensorflow/tfjs':
         specifier: ^4.22.0
         version: 4.22.0(seedrandom@3.0.5)
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
       next:
         specifier: 15.5.4
         version: 15.5.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -762,6 +765,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -825,6 +832,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1191,6 +1201,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1844,6 +1858,9 @@ packages:
     resolution: {integrity: sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==}
     engines: {node: '>=18'}
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -1904,6 +1921,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -2644,6 +2664,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-arraybuffer@1.0.2: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -2712,6 +2734,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   csstype@3.1.3: {}
 
@@ -3229,6 +3255,11 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   ignore@5.3.2: {}
 
@@ -3919,6 +3950,10 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4018,6 +4053,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   webidl-conversions@3.0.1: {}
 

--- a/src/app/components/ResultCard.tsx
+++ b/src/app/components/ResultCard.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+type MixItem = {
+    label: string;
+    percent: number;
+};
+
+interface ResultCardProps {
+    imgUrl: string;
+    mix: MixItem[];
+}
+
+export default function ResultCard({ imgUrl, mix }: ResultCardProps) {
+    return (
+        <div className="w-full max-w-md rounded-xl border p-4 shadow bg-white">
+            {/* 업로드사진 */}
+            <img src={imgUrl} alt="업로드한 반려견" className="w-full rounded-lg object-cover" />
+
+            {/* 결과 */}
+            <div className="mt-4 space-y-2">
+                <h2 className="text-lg font-bold"> 믹스 비율 </h2>
+                {mix.map((item, idx) => (
+                    <div key={idx} className="flex justify-between">
+                        <span>{item.label}</span>
+                        <span>{item.percent}%</span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/app/components/UploadBox.tsx
+++ b/src/app/components/UploadBox.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { resizeImage } from '@/lib/resize';
 import { classifyImage } from '@/lib/mobilenet';
+import { toMixTop3 } from '@/lib/mix';
 
 export default function UploadBox() {
     const [preview, setPreview] = useState<string | null>(null);
@@ -42,8 +43,9 @@ export default function UploadBox() {
     const handleImageLoad = async () => {
         if (!imgRef.current) return;
         try {
-            const preds = await classifyImage(imgRef.current, 5);
-            console.log('[MobileNet Top-5]', preds);
+            const preds = await classifyImage(imgRef.current, 10);
+            const mix = toMixTop3(preds, 3);
+            console.log('[Mix 결과]', mix);
         } catch (e) {
             console.error('추론 실패:', e);
         }
@@ -69,7 +71,7 @@ export default function UploadBox() {
                     className="max-h-[360px] w-auto rounded-lg shadow"
                 />
             ) : (
-                <p className="text-gray-500">반려동물 사진을 업로드하세요 </p>
+                <p className="text-gray-500">강아지 사진을 업로드하세요 </p>
             )}
         </div>
     );

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -9,7 +9,7 @@ export default function ResultPage() {
     const mixData = params.get('mix');
 
     if (!imgUrl || !mixData) {
-        return <p>결과 데이터가 없습니다. 다시 업로드해주세요 🐾</p>;
+        return <p className="p-6">결과 데이터가 없습니다. 다시 업로드해주세요 🐾</p>;
     }
 
     const parsedMix = JSON.parse(mixData);

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import ResultCard from '../components/ResultCard';
+
+export default function ResultPage() {
+    const params = useSearchParams();
+    const imgUrl = params.get('img');
+    const mixData = params.get('mix');
+
+    if (!imgUrl || !mixData) {
+        return <p>결과 데이터가 없습니다. 다시 업로드해주세요 🐾</p>;
+    }
+
+    const parsedMix = JSON.parse(mixData);
+
+    return (
+        <main className="flex flex-col items-center p-6">
+            <ResultCard imgUrl={imgUrl} mix={parsedMix} />
+        </main>
+    );
+}

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -1,0 +1,67 @@
+export type RawPred = { className: string; probability: number };
+
+/* 1) 원본 → 대표키 매핑  */
+const NORMALIZE_MAP: Record<string, string> = {
+    // cats
+    'egyptian cat': 'egyptian_cat',
+    'tabby, tabby cat': 'domestic_cat',
+    'tiger cat': 'domestic_cat',
+    'persian cat': 'persian_cat',
+    'siamese cat': 'siamese_cat',
+    // dogs
+    'maltese dog': 'maltese',
+    'shih-tzu': 'shih_tzu',
+    pug: 'pug',
+    chihuahua: 'chihuahua',
+    pomeranian: 'pomeranian',
+    'yorkshire terrier': 'yorkshire_terrier',
+    'golden retriever': 'golden_retriever',
+    'labrador retriever': 'labrador',
+    'german shepherd': 'german_shepherd',
+    'siberian husky': 'siberian_husky',
+    bulldog: 'bulldog',
+    beagle: 'beagle',
+    poodle: 'poodle',
+    dachshund: 'dachshund',
+};
+
+export function normalizeLabel(label: string) {
+    const key = label.toLowerCase();
+    return NORMALIZE_MAP[key] ?? key;
+}
+
+/* 2)카테고리 세트 */
+const DOG_SET = new Set<string>([
+    'maltese',
+    'shih_tzu',
+    'pug',
+    'chihuahua',
+    'pomeranian',
+    'yorkshire_terrier',
+    'golden_retriever',
+    'labrador',
+    'german_shepherd',
+    'siberian_husky',
+    'bulldog',
+    'beagle',
+    'poodle',
+    'dachshund',
+]);
+const CAT_SET = new Set<string>(['domestic_cat', 'egyptian_cat', 'persian_cat', 'siamese_cat']);
+
+/* 3)개/고양이/기타 분류 */
+export function coarseClass(label: string): 'dog' | 'cat' | 'other' {
+    const key = normalizeLabel(label);
+    if (DOG_SET.has(key)) return 'dog';
+    if (CAT_SET.has(key)) return 'cat';
+    // fallback: 원본에 dog/cat 포함되면 일반 버킷으로 분류
+    const l = label.toLowerCase();
+    if (l.includes('dog')) return 'dog';
+    if (l.includes('cat')) return 'cat';
+    return 'other';
+}
+
+/** 화면용 라벨 */
+export function displayLabel(normKey: string) {
+    return normKey.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -1,67 +1,135 @@
 export type RawPred = { className: string; probability: number };
 
-/* 1) 원본 → 대표키 매핑  */
-const NORMALIZE_MAP: Record<string, string> = {
-    // cats
-    'egyptian cat': 'egyptian_cat',
-    'tabby, tabby cat': 'domestic_cat',
-    'tiger cat': 'domestic_cat',
-    'persian cat': 'persian_cat',
-    'siamese cat': 'siamese_cat',
-    // dogs
-    'maltese dog': 'maltese',
-    'shih-tzu': 'shih_tzu',
-    pug: 'pug',
-    chihuahua: 'chihuahua',
-    pomeranian: 'pomeranian',
-    'yorkshire terrier': 'yorkshire_terrier',
-    'golden retriever': 'golden_retriever',
-    'labrador retriever': 'labrador',
-    'german shepherd': 'german_shepherd',
-    'siberian husky': 'siberian_husky',
-    bulldog: 'bulldog',
-    beagle: 'beagle',
-    poodle: 'poodle',
-    dachshund: 'dachshund',
-};
-
-export function normalizeLabel(label: string) {
-    const key = label.toLowerCase();
-    return NORMALIZE_MAP[key] ?? key;
-}
-
-/* 2)카테고리 세트 */
-const DOG_SET = new Set<string>([
-    'maltese',
-    'shih_tzu',
-    'pug',
-    'chihuahua',
-    'pomeranian',
-    'yorkshire_terrier',
-    'golden_retriever',
-    'labrador',
-    'german_shepherd',
-    'siberian_husky',
-    'bulldog',
+export const DOG_LABELS = [
+    'Chihuahua',
+    'Japanese spaniel',
+    'Maltese dog, Maltese terrier, Maltese',
+    'Pekinese, Pekingese, Peke',
+    'Shih-Tzu',
+    'Blenheim spaniel',
+    'papillon',
+    'toy terrier',
+    'Rhodesian ridgeback',
+    'Afghan hound, Afghan',
+    'basset, basset hound',
     'beagle',
-    'poodle',
-    'dachshund',
-]);
-const CAT_SET = new Set<string>(['domestic_cat', 'egyptian_cat', 'persian_cat', 'siamese_cat']);
+    'bloodhound, sleuthhound',
+    'bluetick',
+    'black-and-tan coonhound',
+    'Walker hound, Walker foxhound',
+    'English foxhound',
+    'redbone',
+    'borzoi, Russian wolfhound',
+    'Irish wolfhound',
+    'Italian greyhound',
+    'whippet',
+    'Ibizan hound, Ibizan Podenco',
+    'Norwegian elkhound, elkhound',
+    'otterhound, otter hound',
+    'Saluki, gazelle hound',
+    'Scottish deerhound, deerhound',
+    'Weimaraner',
+    'Staffordshire bullterrier, Staffordshire bull terrier',
+    'American Staffordshire terrier, Staffordshire terrier, American pit bull terrier, pit bull terrier',
+    'Bedlington terrier',
+    'Border terrier',
+    'Kerry blue terrier',
+    'Irish terrier',
+    'Norfolk terrier',
+    'Norwich terrier',
+    'Yorkshire terrier',
+    'wire-haired fox terrier',
+    'Lakeland terrier',
+    'Sealyham terrier, Sealyham',
+    'Airedale, Airedale terrier',
+    'cairn, cairn terrier',
+    'Australian terrier',
+    'Dandie Dinmont, Dandie Dinmont terrier',
+    'Boston bull, Boston terrier',
+    'miniature schnauzer',
+    'giant schnauzer',
+    'standard schnauzer',
+    'Scotch terrier, Scottish terrier, Scottie',
+    'Tibetan terrier, chrysanthemum dog',
+    'silky terrier, Sydney silky',
+    'soft-coated wheaten terrier',
+    'West Highland white terrier',
+    'Lhasa, Lhasa apso',
+    'flat-coated retriever',
+    'curly-coated retriever',
+    'golden retriever',
+    'Labrador retriever',
+    'Chesapeake Bay retriever',
+    'German short-haired pointer',
+    'vizsla, Hungarian pointer',
+    'English setter',
+    'Irish setter, red setter',
+    'Gordon setter',
+    'Brittany spaniel',
+    'clumber, clumber spaniel',
+    'English springer, English springer spaniel',
+    'Welsh springer spaniel',
+    'cocker spaniel, English cocker spaniel, cocker',
+    'Sussex spaniel',
+    'Irish water spaniel',
+    'kuvasz',
+    'schipperke',
+    'groenendael',
+    'malinois',
+    'briard',
+    'kelpie',
+    'komondor',
+    'Old English sheepdog, bobtail',
+    'Shetland sheepdog, Shetland sheep dog, Shetland',
+    'collie',
+    'Border collie',
+    'Bouvier des Flandres, Bouviers des Flandres',
+    'Rottweiler',
+    'German shepherd, German shepherd dog, German police dog, alsatian',
+    'Doberman, Doberman pinscher',
+    'miniature pinscher',
+    'Greater Swiss Mountain dog',
+    'Bernese mountain dog',
+    'Appenzeller',
+    'EntleBucher',
+    'boxer',
+    'bull mastiff',
+    'Tibetan mastiff',
+    'French bulldog',
+    'Great Dane',
+    'Saint Bernard, St Bernard',
+    'Eskimo dog, husky',
+    'malamute, malemute, Alaskan malamute',
+    'Siberian husky',
+    'dalmatian, coach dog, carriage dog',
+    'affenpinscher, monkey pinscher, monkey dog',
+    'basenji',
+    'pug, pug-dog',
+    'Leonberg',
+    'Newfoundland, Newfoundland dog',
+    'Great Pyrenees',
+    'Samoyed, Samoyede',
+    'Pomeranian',
+    'chow, chow chow',
+    'keeshond',
+    'Brabancon griffon',
+    'Pembroke, Pembroke Welsh corgi',
+    'Cardigan, Cardigan Welsh corgi',
+    'toy poodle',
+    'miniature poodle',
+    'standard poodle',
+    'Mexican hairless',
+];
 
-/* 3)개/고양이/기타 분류 */
-export function coarseClass(label: string): 'dog' | 'cat' | 'other' {
-    const key = normalizeLabel(label);
-    if (DOG_SET.has(key)) return 'dog';
-    if (CAT_SET.has(key)) return 'cat';
-    // fallback: 원본에 dog/cat 포함되면 일반 버킷으로 분류
+export function isDog(label: string) {
     const l = label.toLowerCase();
-    if (l.includes('dog')) return 'dog';
-    if (l.includes('cat')) return 'cat';
-    return 'other';
+    return DOG_LABELS.some(x => x.toLowerCase() === l);
 }
 
-/** 화면용 라벨 */
-export function displayLabel(normKey: string) {
-    return normKey.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+export function displayLabel(label: string) {
+    let first = (label.split(',')[0] ?? label).trim();
+
+    first = first.replace(/\bdog\b\s*$/i, '').trim();
+    first = first.replace(/[-_]/g, ' ').replace(/\s+/g, ' ');
+    return first.replace(/\b\w/g, c => c.toUpperCase());
 }

--- a/src/lib/mix.ts
+++ b/src/lib/mix.ts
@@ -1,47 +1,29 @@
 import type { RawPred } from './labels';
-import { normalizeLabel, coarseClass, displayLabel } from './labels';
+import { isDog, displayLabel } from './labels';
 
-/**
- * 예측값 배열에서 품종만 추려 대표키로 합산 → 상위 3개 100% 정규화
- */
 export function toMixTop3(preds: RawPred[], topK = 3) {
-    // 1. 종 별로 합산할 버킷 준비
     const bucket = new Map<string, number>();
 
     for (const p of preds) {
-        // 멍냥 분류
-        const cls = coarseClass(p.className);
-        if (cls === 'other') continue;
+        const raw = p.className;
+        if (!isDog(raw)) continue;
 
-        let key = normalizeLabel(p.className);
-
-        if (cls === 'dog' && !key.includes('dog') && !key.includes('_')) key = 'dog_generic';
-        if (cls === 'cat' && !key.includes('cat') && !key.includes('_')) key = 'cat_generic';
-
-        bucket.set(key, (bucket.get(key) ?? 0) + p.probability);
+        const label = displayLabel(raw);
+        bucket.set(label, (bucket.get(label) ?? 0) + p.probability);
     }
 
-    // 멍냥 관련 라벨이 없으면 빈 배열
     if (bucket.size === 0) return [];
 
-    // 2. Map → 배열 변환 후 내림차순
     const arr = [...bucket.entries()]
-        .map(([key, value]) => ({
-            key,
-
-            label: key === 'dog_generic' ? 'Dog' : key === 'cat_generic' ? 'Cat' : displayLabel(key),
-            value,
-        }))
+        .map(([label, value]) => ({ label, value }))
         .sort((a, b) => b.value - a.value)
         .slice(0, topK);
 
-    // 3. 100%로 정규화
     const sum = arr.reduce((s, x) => s + x.value, 0);
     const out = arr.map(x => ({ label: x.label, percent: Math.round((x.value / sum) * 100) }));
 
-    // 4. 반올림 오차 보정
     const diff = 100 - out.reduce((s, x) => s + x.percent, 0);
     if (out.length && diff) out[out.length - 1].percent += diff;
 
-    return out;
+    return out.filter(x => x.percent > 0);
 }

--- a/src/lib/mix.ts
+++ b/src/lib/mix.ts
@@ -1,0 +1,47 @@
+import type { RawPred } from './labels';
+import { normalizeLabel, coarseClass, displayLabel } from './labels';
+
+/**
+ * 예측값 배열에서 품종만 추려 대표키로 합산 → 상위 3개 100% 정규화
+ */
+export function toMixTop3(preds: RawPred[], topK = 3) {
+    // 1. 종 별로 합산할 버킷 준비
+    const bucket = new Map<string, number>();
+
+    for (const p of preds) {
+        // 멍냥 분류
+        const cls = coarseClass(p.className);
+        if (cls === 'other') continue;
+
+        let key = normalizeLabel(p.className);
+
+        if (cls === 'dog' && !key.includes('dog') && !key.includes('_')) key = 'dog_generic';
+        if (cls === 'cat' && !key.includes('cat') && !key.includes('_')) key = 'cat_generic';
+
+        bucket.set(key, (bucket.get(key) ?? 0) + p.probability);
+    }
+
+    // 멍냥 관련 라벨이 없으면 빈 배열
+    if (bucket.size === 0) return [];
+
+    // 2. Map → 배열 변환 후 내림차순
+    const arr = [...bucket.entries()]
+        .map(([key, value]) => ({
+            key,
+
+            label: key === 'dog_generic' ? 'Dog' : key === 'cat_generic' ? 'Cat' : displayLabel(key),
+            value,
+        }))
+        .sort((a, b) => b.value - a.value)
+        .slice(0, topK);
+
+    // 3. 100%로 정규화
+    const sum = arr.reduce((s, x) => s + x.value, 0);
+    const out = arr.map(x => ({ label: x.label, percent: Math.round((x.value / sum) * 100) }));
+
+    // 4. 반올림 오차 보정
+    const diff = 100 - out.reduce((s, x) => s + x.percent, 0);
+    if (out.length && diff) out[out.length - 1].percent += diff;
+
+    return out;
+}

--- a/src/lib/resize.ts
+++ b/src/lib/resize.ts
@@ -11,18 +11,18 @@ export async function resizeImage(
         // 파일 읽기 성공
         reader.onload = e => {
             const src = e.target?.result as string | undefined;
-            if (!src) return reject(new Error('멍냥 이미지를 읽을 수 없습니다'));
+            if (!src) return reject(new Error('강아지 이미지를 읽을 수 없습니다'));
             img.src = src;
         };
 
         // 파일 읽기 실패
         reader.onerror = () => {
-            reject(new Error('멍냥 이미지 읽기 실패'));
+            reject(new Error('강아지 이미지 읽기 실패'));
         };
 
         // 이미지 로드 실패
         img.onerror = () => {
-            reject(new Error('멍냥 이미지 로드 실패'));
+            reject(new Error('강아지 이미지 로드 실패'));
         };
 
         // 이미지 로드 성공


### PR DESCRIPTION
## 기능

업로드된 반려견 이미지를 클라이언트에서 분류하고, 그 결과를 Top-3 믹스 비율로 시각화하는 기능을 추가했습니다. 
라우팅을 분리하여 결과 확인 페이지를 완성했습니다.

## 주요 변경 사항
1. 홈에서 반려견 사진 업로드(uploadBox) -> 결과 페이지에서 믹스 비율 카드 확인
2. 라벨 
     - 일부 라벨 묶음(예: Maltese dog, Maltese terrier, Maltese)은 첫 토큰 기준 표기하기로 함
     - 추론결과는 강아지관련 데이터만 나오게 함 사물/고양이/다른 동물 []
     - MobileNet 라벨 중 강아지 품종 라벨만 필터링
3. 믹스 비율 계산 top3 %로
     - 예측값 배열(RawPred[]) → Top-3 품종 + 정규화된 % 결과


## 예정

- ResultCard UI/UX 개선 (컬러, 간격, ProgressBar 만들어서 ui개선)
- 폰트 및 로고(발자국) 등 디자인 요소 추가
- 표시 라벨 한/영 전환 스위치 추가

## 스크린샷
 ### 1)결과카드가 렌더링 된 화면
<img width="704" height="742" alt="image" src="https://github.com/user-attachments/assets/e82500d6-f677-45a6-9d89-7633ba15754e" />

### 2) 콘솔 테스트
<img width="618" height="118" alt="image" src="https://github.com/user-attachments/assets/e73bfed5-5161-432b-bdc0-f4d68827ecb5" />


 ## 🐾 고양이 품종 분석 제외 사유 
사용하는 모델(MobileNet v2) 데이터셋 한계
- 기술적 한계: 사용된 모델의 데이터셋은 강아지 품종은 약 120개를 포함하는 반면, 고양이 품종은 5개 이하로 매우 제한적
- 결론: 정확한 믹스 비율을 도출하기 어렵다고 판단하여, 현재 버전에서는 고양이 관련 추론 결과는 제외 아쉽다🐱
- 데이터셋 참고(IMAGENET): Class ID no.151-275
[데이터셋 참고 링크](https://deeplearning.cms.waikato.ac.nz/user-guide/class-maps/IMAGENET/)




